### PR TITLE
Add global ActionStack variable in a way compatible with strict mode

### DIFF
--- a/src/ActionStack.js
+++ b/src/ActionStack.js
@@ -24,7 +24,7 @@ SOFTWARE.
 
 */
 
-ActionStack = function(stackSize) {
+var ActionStack = ActionStack || function(stackSize) {
 
 	// this determines how many actions can be queued
 	var _stackSize = stackSize !== undefined ? stackSize : 3;


### PR DESCRIPTION
Our build environment turns everything into strict mode, which breaks "var-less" global variables.